### PR TITLE
feat: add OpenAI test on options page

### DIFF
--- a/agent/task/2025/08/28/0509-test-openai-button.md
+++ b/agent/task/2025/08/28/0509-test-openai-button.md
@@ -1,0 +1,10 @@
+# Task: add Test OpenAI button
+
+## Summary
+- Added a test provider for OpenAI requests.
+- Extended options page with **Test OpenAI** button and popup.
+- Created mock and tests for provider scenarios.
+- Documented component and flow for provider check.
+
+## Observations
+- NPM packages `openai` and `@teqfw/di` were unavailable in this environment, preventing tests from running locally.

--- a/spec/arch/components/README.md
+++ b/spec/arch/components/README.md
@@ -1,0 +1,7 @@
+# Components
+
+## Options page
+- file: `src/html/options.html`
+- fields `baseUrl`, `model`, `apiKey` with `Save` button
+- **Test OpenAI button** runs a short request using saved settings and shows the response in a popup
+- popup contains title `OpenAI test`, result text and a `Close` button

--- a/spec/arch/flows/README.md
+++ b/spec/arch/flows/README.md
@@ -1,0 +1,8 @@
+# Flows
+
+## Provider check
+1. User fills settings on options page.
+2. User presses **Test OpenAI**.
+3. UI requests `GptExt_Provider_TestOpenAI` via DI container.
+4. Service loads settings, calls OpenAI and maps errors.
+5. Result text is shown in a popup; user closes it.

--- a/src/css/options.css
+++ b/src/css/options.css
@@ -23,3 +23,26 @@ button {
   font-size: 12px;
   opacity: 0.7;
 }
+
+#popup-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+#popup-backdrop .popup {
+  background: #fff;
+  padding: 20px;
+  max-width: 90%;
+  max-height: 80%;
+  overflow: auto;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+}
+
+#popup-backdrop pre {
+  white-space: pre-wrap;
+  margin-bottom: 10px;
+}

--- a/src/html/options.html
+++ b/src/html/options.html
@@ -21,6 +21,7 @@
         <input type="password" id="apiKey" placeholder="sk-..." />
       </label>
       <button id="save">Save</button>
+      <button id="btn-test-openai" disabled>Test OpenAI</button>
       <p id="status"></p>
     </main>
     <script type="module" src="../js/options.entry.js"></script>

--- a/src/js/di/Provider/TestOpenAI.js
+++ b/src/js/di/Provider/TestOpenAI.js
@@ -1,0 +1,54 @@
+// Comments in code must be in English
+export default class GptExt_Provider_TestOpenAI {
+  /** @param {{ openai_index: any, GptExt_Store_SettingsRepo$: any }} deps */
+  constructor({ openai_index, GptExt_Store_SettingsRepo$ }) {
+    // Use default export or namespace style
+    const pkg = openai_index?.default ?? openai_index;
+    this._OpenAI = pkg?.OpenAI;
+    this._repo = GptExt_Store_SettingsRepo$;
+  }
+
+  async run() {
+    // Load saved settings
+    const { baseUrl, model, apiKey } = await this._repo.load();
+
+    // Validate settings
+    if (!baseUrl) throw new Error("Missing baseUrl");
+    if (!model) throw new Error("Missing model");
+    if (!apiKey) throw new Error("Missing apiKey");
+
+    // Setup abort controller with 20s timeout
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 20_000);
+
+    try {
+      const client = new this._OpenAI({ apiKey, baseURL: baseUrl });
+      const resp = await client.chat.completions.create(
+        {
+          model,
+          messages: [{ role: "user", content: "что ты знаешь про TeqFW?" }],
+          temperature: 0.2,
+        },
+        { signal: controller.signal }
+      );
+      const text = resp?.choices?.[0]?.message?.content ?? "";
+      return text.length > 8000 ? text.slice(0, 8000) : text;
+    } catch (e) {
+      const msg = String(e?.message || e || "");
+      if (e?.status === 401 || e?.status === 403 || /401|403/.test(msg)) {
+        return "Unauthorized / Forbidden. Check API key or org settings.";
+      }
+      if (e?.status === 429 || /429/.test(msg)) return "Rate limit.";
+      if (e?.status >= 500 && e?.status < 600 || /5\d\d/.test(msg)) {
+        return "Upstream error.";
+      }
+      if (e?.name === "AbortError" || /aborted|timeout|network/i.test(msg)) {
+        return "Network/timeout.";
+      }
+      return msg || "Unknown error";
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+}
+

--- a/src/js/options.entry.js
+++ b/src/js/options.entry.js
@@ -2,25 +2,59 @@ import container from "./container.js";
 
 document.addEventListener("DOMContentLoaded", async () => {
   const repo = await container.get("GptExt_Store_SettingsRepo$");
+  const tester = await container.get("GptExt_Provider_TestOpenAI$");
 
-  debugger;
+  const baseEl = document.getElementById("baseUrl");
+  const modelEl = document.getElementById("model");
+  const keyEl = document.getElementById("apiKey");
+  const testBtn = document.getElementById("btn-test-openai");
 
   const settings = await repo.load();
   if (settings) {
-    document.getElementById("baseUrl").value = settings.baseUrl || "";
-    document.getElementById("model").value = settings.model || "";
-    document.getElementById("apiKey").value = settings.apiKey || "";
+    baseEl.value = settings.baseUrl || "";
+    modelEl.value = settings.model || "";
+    keyEl.value = settings.apiKey || "";
   }
+
+  const updateTestBtn = () => {
+    testBtn.disabled = !(baseEl.value.trim() && modelEl.value.trim() && keyEl.value.trim());
+  };
+  updateTestBtn();
+
+  [baseEl, modelEl, keyEl].forEach((el) => el.addEventListener("input", updateTestBtn));
 
   document.getElementById("save").addEventListener("click", async () => {
     const newSettings = {
-      baseUrl: document.getElementById("baseUrl").value.trim(),
-      model: document.getElementById("model").value.trim(),
-      apiKey: document.getElementById("apiKey").value.trim(),
+      baseUrl: baseEl.value.trim(),
+      model: modelEl.value.trim(),
+      apiKey: keyEl.value.trim(),
     };
     await repo.save(newSettings);
     const status = document.getElementById("status");
     status.textContent = "Settings saved.";
     setTimeout(() => (status.textContent = ""), 2000);
+    updateTestBtn();
   });
+
+  testBtn.addEventListener("click", async () => {
+    const text = await tester.run();
+    showPopup(text);
+  });
+
+  function showPopup(text) {
+    const backdrop = document.createElement("div");
+    backdrop.id = "popup-backdrop";
+    const box = document.createElement("div");
+    box.className = "popup";
+    const title = document.createElement("h2");
+    title.textContent = "OpenAI test";
+    const body = document.createElement("pre");
+    body.textContent = text;
+    const close = document.createElement("button");
+    close.textContent = "Close";
+    close.addEventListener("click", () => backdrop.remove());
+    box.append(title, body, close);
+    backdrop.append(box);
+    document.body.append(backdrop);
+  }
 });

--- a/test/openai.mock.js
+++ b/test/openai.mock.js
@@ -1,0 +1,25 @@
+// Simple mock for OpenAI package
+export class OpenAI {
+  constructor(opts = {}) {
+    this.apiKey = opts.apiKey;
+  }
+
+  models = {
+    async list() {
+      return { data: [{ id: "mock-model" }] };
+    },
+  };
+
+  chat = {
+    completions: {
+      create: async () => {
+        if (this.apiKey === "401") throw new Error("401 Unauthorized");
+        if (this.apiKey === "429") throw new Error("429 Too Many Requests");
+        if (this.apiKey === "timeout") throw new Error("aborted");
+        return { choices: [{ message: { content: "mock-response" } }] };
+      },
+    },
+  };
+}
+
+export default { OpenAI };

--- a/test/provider.test.js
+++ b/test/provider.test.js
@@ -1,0 +1,42 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import container from "../src/js/container.js";
+import openaiMock from "./openai.mock.js";
+
+container.enableTestMode();
+
+const repoFactory = (settings) => ({
+  async load() {
+    return settings;
+  },
+});
+
+const getTester = async (settings) => {
+  container.register("openai_index", openaiMock);
+  container.register("GptExt_Store_SettingsRepo$", repoFactory(settings));
+  return await container.get("GptExt_Provider_TestOpenAI$$");
+};
+
+test("returns text on success", async () => {
+  const tester = await getTester({ baseUrl: "x", model: "m", apiKey: "ok" });
+  const res = await tester.run();
+  assert.equal(res, "mock-response");
+});
+
+test("maps 401 to friendly message", async () => {
+  const tester = await getTester({ baseUrl: "x", model: "m", apiKey: "401" });
+  const res = await tester.run();
+  assert.equal(res, "Unauthorized / Forbidden. Check API key or org settings.");
+});
+
+test("maps 429 to rate limit", async () => {
+  const tester = await getTester({ baseUrl: "x", model: "m", apiKey: "429" });
+  const res = await tester.run();
+  assert.equal(res, "Rate limit.");
+});
+
+test("maps aborted request to timeout", async () => {
+  const tester = await getTester({ baseUrl: "x", model: "m", apiKey: "timeout" });
+  const res = await tester.run();
+  assert.equal(res, "Network/timeout.");
+});


### PR DESCRIPTION
## Summary
- add provider to run a short OpenAI request using saved settings
- add **Test OpenAI** button with popup on options page
- document provider check flow and component

## Testing
- `npm test` *(fails: Cannot find module '/workspace/chrome-ext-gpt/node_modules/@teqfw/di/src/Container.js')*

------
https://chatgpt.com/codex/tasks/task_e_68afe39584bc832d829a85fa87d6de05