### PR TITLE
Add toolbar popup menu

### DIFF
--- a/agent/task/2025/08/29/0608-add-toolbar-btn.md
+++ b/agent/task/2025/08/29/0608-add-toolbar-btn.md
@@ -1,0 +1,15 @@
+# Task: Add toolbar button with popup menu
+
+## Summary
+- Added action configuration with toolbar icon and popup in `manifest.json`.
+- Implemented `popup.html` and `popup.js` to render a dynamic menu.
+- Created `background.js` to handle `openDialog` messages and open a tab.
+- Added placeholder `src/img/` directory for future icon files.
+
+## Observations
+- `SettingsRepo` currently returns a settings object; menu data should be stored under `settings.menu` to populate the popup.
+- The background handler opens the options page as a stand-in for the Assistant UI.
+
+## Suggestions
+- Replace the options page URL with the real Assistant page once available.
+- Extend settings storage to include menu definitions for popup entries.

--- a/manifest.json
+++ b/manifest.json
@@ -6,5 +6,17 @@
   "options_page": "src/html/options.html",
   "permissions": ["storage"],
   "host_permissions": ["https://api.openai.com/*"],
-  "action": { "default_title": "Chrome GPT" }
+  "background": {
+    "service_worker": "src/js/background.js",
+    "type": "module"
+  },
+  "action": {
+    "default_title": "Chrome GPT",
+    "default_popup": "src/html/popup.html",
+    "default_icon": {
+      "16": "src/img/icon16.png",
+      "48": "src/img/icon48.png",
+      "128": "src/img/icon128.png"
+    }
+  }
 }

--- a/src/html/popup.html
+++ b/src/html/popup.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Chrome GPT Menu</title>
+  </head>
+  <body>
+    <ul id="menu"></ul>
+    <script type="module" src="../js/popup.js"></script>
+  </body>
+</html>

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -1,0 +1,7 @@
+// Listen for messages from popup menu and open Assistant dialog
+chrome.runtime.onMessage.addListener((message) => {
+  if (message && message.action === "openDialog") {
+    // AGENT: replace URL with Assistant page when implemented
+    chrome.tabs.create({ url: chrome.runtime.getURL("src/html/options.html") });
+  }
+});

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -1,0 +1,17 @@
+import container from "./container.js";
+
+document.addEventListener("DOMContentLoaded", async () => {
+  const repo = await container.get("GptExt_Store_SettingsRepo$");
+  const settings = (await repo.load()) || {};
+  const menu = Array.isArray(settings.menu) ? settings.menu : [];
+
+  const ul = document.getElementById("menu");
+  menu.forEach((opt) => {
+    const li = document.createElement("li");
+    li.textContent = opt.name;
+    li.addEventListener("click", () => {
+      chrome.runtime.sendMessage({ action: "openDialog", payload: opt });
+    });
+    ul.appendChild(li);
+  });
+});


### PR DESCRIPTION
## Summary
- add toolbar action with popup rendered from settings
- handle `openDialog` messages in background
- reference toolbar icons under `src/img/` for later addition

## Testing
- `npm install` *(fails: 403 Forbidden - openai package)*
- `npm test` *(fails: Cannot find module '@teqfw/di/src/Container.js')*

------
https://chatgpt.com/codex/tasks/task_e_68b11a8b2254832d8420a95079f72fb3