### PR TITLE
feat: add toolbar menu and prompt manager

### DIFF
--- a/agent/task/2025/08/30/0936-toolbar-menu-prompts.md
+++ b/agent/task/2025/08/30/0936-toolbar-menu-prompts.md
@@ -1,0 +1,12 @@
+# Task: Add toolbar menu and prompt manager page
+
+## Summary
+- Added static toolbar menu with links to options and prompt manager pages.
+- Implemented new prompt manager page with IndexedDB storage for adding and deleting prompts.
+
+## Observations
+- Existing dynamic menu based on settings was replaced with static entries.
+- Tests failed due to missing `@teqfw/di` dependency and `npm ci` could not download `openai` package (403 Forbidden).
+
+## Suggestions
+- Investigate dependency installation issue to enable automated tests.

--- a/src/css/prompts.css
+++ b/src/css/prompts.css
@@ -1,0 +1,12 @@
+ul {
+  list-style: none;
+  padding: 0;
+}
+
+li {
+  margin: 0.5rem 0;
+}
+
+button {
+  margin-left: 0.5rem;
+}

--- a/src/html/prompts.html
+++ b/src/html/prompts.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Prompt Manager</title>
+    <link rel="stylesheet" href="../css/prompts.css" />
+  </head>
+  <body>
+    <main>
+      <h1>Prompts</h1>
+      <ul id="prompt-list"></ul>
+      <input type="text" id="new-prompt" placeholder="New prompt" />
+      <button id="add">Add</button>
+    </main>
+    <script type="module" src="../js/prompts.entry.js"></script>
+  </body>
+</html>

--- a/src/html/toolbar/action.html
+++ b/src/html/toolbar/action.html
@@ -5,32 +5,10 @@
     <title>Chrome GPT Menu</title>
   </head>
   <body>
-    <ul id="menu"></ul>
+    <ul id="menu">
+      <li id="open-options">Options</li>
+      <li id="open-prompts">Prompts</li>
+    </ul>
     <script type="module" src="../../js/action.js"></script>
   </body>
-  <script>
-    import container from "../../js/container.js";
-
-    document.addEventListener("DOMContentLoaded", async () => {
-      const repo = await container.get("GptExt_Store_SettingsRepo$");
-      const settings = (await repo.load()) || {};
-      const menu = Array.isArray(settings.menu)
-        ? settings.menu
-        : [
-            { name: "First", url: "https://chat.openai.com/" },
-            { name: "Second", url: "https://chat.openai.com/" },
-            { name: "Third", url: "https://chat.openai.com/" },
-          ];
-
-      const ul = document.getElementById("menu");
-      menu.forEach((opt) => {
-        const li = document.createElement("li");
-        li.textContent = opt.name;
-        li.addEventListener("click", () => {
-          chrome.runtime.sendMessage({ action: "openDialog", payload: opt });
-        });
-        ul.appendChild(li);
-      });
-    });
-  </script>
 </html>

--- a/src/js/action.js
+++ b/src/js/action.js
@@ -1,17 +1,13 @@
-import container from "./container.js";
+document.addEventListener('DOMContentLoaded', () => {
+  const optionsBtn = document.getElementById('open-options');
+  const promptsBtn = document.getElementById('open-prompts');
 
-document.addEventListener("DOMContentLoaded", async () => {
-  const repo = await container.get("GptExt_Store_SettingsRepo$");
-  const settings = (await repo.load()) || {};
-  const menu = Array.isArray(settings.menu) ? settings.menu : [{name:'First',url:'https://chat.openai.com/'},{name:'Second',url:'https://chat.openai.com/'},{name:'Third',url:'https://chat.openai.com/'}];
+  optionsBtn.addEventListener('click', () => {
+    chrome.runtime.openOptionsPage();
+  });
 
-  const ul = document.getElementById("menu");
-  menu.forEach((opt) => {
-    const li = document.createElement("li");
-    li.textContent = opt.name;
-    li.addEventListener("click", () => {
-      chrome.runtime.sendMessage({ action: "openDialog", payload: opt });
-    });
-    ul.appendChild(li);
+  promptsBtn.addEventListener('click', () => {
+    const url = chrome.runtime.getURL('src/html/prompts.html');
+    chrome.tabs.create({ url });
   });
 });

--- a/src/js/prompts.entry.js
+++ b/src/js/prompts.entry.js
@@ -1,0 +1,78 @@
+const DB_NAME = 'gptExt';
+const STORE_NAME = 'prompts';
+let db;
+
+function openDb() {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, 1);
+    request.onupgradeneeded = () => {
+      request.result.createObjectStore(STORE_NAME, { keyPath: 'id', autoIncrement: true });
+    };
+    request.onsuccess = () => {
+      db = request.result;
+      resolve();
+    };
+    request.onerror = () => reject(request.error);
+  });
+}
+
+function getAllPrompts() {
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readonly');
+    const store = tx.objectStore(STORE_NAME);
+    const request = store.getAll();
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+function addPrompt(text) {
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readwrite');
+    const store = tx.objectStore(STORE_NAME);
+    const request = store.add({ text });
+    request.onsuccess = () => resolve();
+    request.onerror = () => reject(request.error);
+  });
+}
+
+function deletePrompt(id) {
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readwrite');
+    const store = tx.objectStore(STORE_NAME);
+    const request = store.delete(id);
+    request.onsuccess = () => resolve();
+    request.onerror = () => reject(request.error);
+  });
+}
+
+function render(prompts) {
+  const list = document.getElementById('prompt-list');
+  list.innerHTML = '';
+  prompts.forEach((p) => {
+    const li = document.createElement('li');
+    li.textContent = p.text;
+    const btn = document.createElement('button');
+    btn.textContent = 'Delete';
+    btn.addEventListener('click', async () => {
+      await deletePrompt(p.id);
+      render(await getAllPrompts());
+    });
+    li.appendChild(btn);
+    list.appendChild(li);
+  });
+}
+
+document.getElementById('add').addEventListener('click', async () => {
+  const input = document.getElementById('new-prompt');
+  const text = input.value.trim();
+  if (text) {
+    await addPrompt(text);
+    input.value = '';
+    render(await getAllPrompts());
+  }
+});
+
+openDb().then(async () => {
+  render(await getAllPrompts());
+});


### PR DESCRIPTION
## Summary
- add menu entries for options and prompt manager
- scaffold prompt manager page with IndexedDB storage

## Testing
- `npm test` *(fails: Cannot find module '@teqfw/di')*
- `npm ci` *(fails: 403 Forbidden for openai package)*

------
https://chatgpt.com/codex/tasks/task_e_68b2c5a4ea00832d9f790c9b65461e5b